### PR TITLE
ensure Django 3.0 compatibility, fixing issue #3

### DIFF
--- a/web/system/templates/system/component/detail.html
+++ b/web/system/templates/system/component/detail.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- IMPORTANT: Load static files -->
-    {% load staticfiles %}
+    {% load static %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">

--- a/web/system/templates/system/component/edit.html
+++ b/web/system/templates/system/component/edit.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- IMPORTANT: Load static files -->
-    {% load staticfiles %}
+    {% load static %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">

--- a/web/system/templates/system/component/list.html
+++ b/web/system/templates/system/component/list.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- IMPORTANT: Load static files -->
-    {% load staticfiles %}
+    {% load static %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">

--- a/web/system/templates/system/configuration/home.html
+++ b/web/system/templates/system/configuration/home.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- IMPORTANT: Load static files -->
-    {% load staticfiles %}
+    {% load static %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">

--- a/web/system/templates/system/home.html
+++ b/web/system/templates/system/home.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- IMPORTANT: Load static files -->
-    {% load staticfiles %}
+    {% load static %}    
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">

--- a/web/system/templates/system/project/edit.html
+++ b/web/system/templates/system/project/edit.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- IMPORTANT: Load static files -->
-    {% load staticfiles %}
+    {% load static %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">

--- a/web/system/templates/system/project/list.html
+++ b/web/system/templates/system/project/list.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- IMPORTANT: Load static files -->
-    {% load staticfiles %}
+    {% load static %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">

--- a/web/system/templates/system/visualization/list.html
+++ b/web/system/templates/system/visualization/list.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- IMPORTANT: Load static files -->
-    {% load staticfiles %}
+    {% load static %}
     {% load humanize %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/web/system/templates/system/visualization/plot.html
+++ b/web/system/templates/system/visualization/plot.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- IMPORTANT: Load static files -->
-    {% load staticfiles %}
+    {% load static %}
     {% load humanize %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <!-- IMPORTANT: Load static files -->
-    {% load staticfiles %}
+    {% load static %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">


### PR DESCRIPTION
Updated all html files of mswh web app to allow for compatibility with Django 3.0.

This fixes issue #3 

This way of loading static files has been deprecated in Django 2.1, see more details here:
https://stackoverflow.com/questions/55929472/django-templatesyntaxerror-staticfiles-is-not-a-registered-tag-library